### PR TITLE
TW-499: only show accepted events in user story

### DIFF
--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -988,7 +988,9 @@ class Room {
   }
 
   /// Call the Matrix API to invite a user to this room.
-  Future<void> invite(String userID) => client.inviteUser(id, userID);
+  Future<void> invite(String userID, {
+    String reason = 'Welcome',
+  }) => client.inviteUser(id, userID, reason: reason);
 
   /// Request more previous events from the server. [historyCount] defines how much events should
   /// be received maximum. When the request is answered, [onHistoryReceived] will be triggered **before**


### PR DESCRIPTION
Now we want to remove all events except the 'You created a group chat' event when we create a group chat, but the invitation when first create the room is the same with later using API, so I make a hack with default `reason = 'Welcome'` to distinguish two invitation events