### PR TITLE
TW-504: add custom field for push rule condition

### DIFF
--- a/lib/matrix.dart
+++ b/lib/matrix.dart
@@ -62,6 +62,8 @@ export 'src/utils/models/encrypted_file_key.dart';
 export 'src/utils/models/file_info.dart';
 export 'src/utils/models/image_file_info.dart';
 export 'src/utils/models/video_file_info.dart';
+export 'src/utils/push_rule_key_const.dart';
+export 'src/utils/push_rule_pattern_const.dart';
 
 export 'msc_extensions/extension_recent_emoji/recent_emoji.dart';
 export 'msc_extensions/msc_3935_cute_events/msc_3935_cute_events.dart';

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -772,7 +772,7 @@ class Room {
     String? threadRootEventId,
     String? threadLastEventId,
   }) async {
-    content[PushRuleKeyConst.ChatType] = isDirectChat 
+    content[PushRuleKeyConst.chatType] = isDirectChat 
       ? PushRulePatternConst.directChat 
       : PushRulePatternConst.groupChat;
     // Create new transaction id

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -29,6 +29,8 @@ import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:matrix/src/utils/crypto/crypto.dart';
 import 'package:matrix/src/utils/markdown.dart';
 import 'package:matrix/src/utils/marked_unread.dart';
+import 'package:matrix/src/utils/push_rule_key_const.dart';
+import 'package:matrix/src/utils/push_rule_pattern_const.dart';
 import 'package:matrix/src/utils/space_child.dart';
 
 enum PushRuleState { notify, mentionsOnly, dontNotify }
@@ -466,6 +468,13 @@ class Room {
         '',
         {'name': newName},
       );
+  
+  Future<String> changeName(String newName) => client.setRoomStateWithKey(
+        id,
+        EventTypes.RoomName,
+        '',
+        {'name': newName, PushRuleKeyConst.roomState: PushRulePatternConst.roomCreated},
+      );
 
   /// Call the Matrix API to change the topic of this room.
   Future<String> setDescription(String newName) => client.setRoomStateWithKey(
@@ -763,6 +772,9 @@ class Room {
     String? threadRootEventId,
     String? threadLastEventId,
   }) async {
+    content[PushRuleKeyConst.ChatType] = isDirectChat 
+      ? PushRulePatternConst.directChat 
+      : PushRulePatternConst.groupChat;
     // Create new transaction id
     final String messageID;
     if (txid == null) {
@@ -1561,6 +1573,7 @@ class Room {
       EventTypes.RoomAvatar,
       '',
       {
+        PushRuleKeyConst.roomState: PushRulePatternConst.roomCreated,
         if (uploadResp != null) 'url': uploadResp.toString(),
       },
     );

--- a/lib/src/room.dart
+++ b/lib/src/room.dart
@@ -1573,6 +1573,20 @@ class Room {
       EventTypes.RoomAvatar,
       '',
       {
+        if (uploadResp != null) 'url': uploadResp.toString(),
+      },
+    );
+  }
+
+  Future<String> changeAvatar(MatrixFile? file) async {
+    final uploadResp = file == null && file!.bytes != null
+        ? null
+        : await client.uploadContent(file.bytes!, filename: file.name);
+    return await client.setRoomStateWithKey(
+      id,
+      EventTypes.RoomAvatar,
+      '',
+      {
         PushRuleKeyConst.roomState: PushRulePatternConst.roomCreated,
         if (uploadResp != null) 'url': uploadResp.toString(),
       },

--- a/lib/src/utils/push_rule_key_const.dart
+++ b/lib/src/utils/push_rule_key_const.dart
@@ -1,0 +1,5 @@
+class PushRuleKeyConst {
+  static const String roomState = 'roomState';
+  static const String powerLevel = 'powerLevel';
+  static const String ChatType = 'chat_type';
+}

--- a/lib/src/utils/push_rule_key_const.dart
+++ b/lib/src/utils/push_rule_key_const.dart
@@ -1,5 +1,4 @@
 class PushRuleKeyConst {
   static const String roomState = 'room_state';
-  static const String powerLevel = 'power_level';
-  static const String ChatType = 'chat_type';
+  static const String chatType = 'chat_type';
 }

--- a/lib/src/utils/push_rule_key_const.dart
+++ b/lib/src/utils/push_rule_key_const.dart
@@ -1,5 +1,5 @@
 class PushRuleKeyConst {
-  static const String roomState = 'roomState';
-  static const String powerLevel = 'powerLevel';
+  static const String roomState = 'room_state';
+  static const String powerLevel = 'power_level';
   static const String ChatType = 'chat_type';
 }

--- a/lib/src/utils/push_rule_pattern_const.dart
+++ b/lib/src/utils/push_rule_pattern_const.dart
@@ -1,0 +1,6 @@
+class PushRulePatternConst {
+  static const String roomCreated = 'created';
+  static const String powerAdmin = '100';
+  static const String directChat = 'direct_chat';
+  static const String groupChat = 'group_chat';
+}

--- a/lib/src/utils/push_rule_pattern_const.dart
+++ b/lib/src/utils/push_rule_pattern_const.dart
@@ -1,6 +1,5 @@
 class PushRulePatternConst {
   static const String roomCreated = 'created';
-  static const String powerAdmin = '100';
   static const String directChat = 'direct_chat';
   static const String groupChat = 'group_chat';
 }


### PR DESCRIPTION
###  To enable/disable direct chat and group chat notification separately: 
- it must have a way to distinguish messages coming from direct Chat and group chat. Every sends messages and images, files,... in room using `sendEvent()` function and we need to add to content of message - direct chat or group chat flag

### To enable/disable invite to room, change group name, group avatar notifications separately:
-when the room is created, it call API to change group name and group avatar also, so we need to create `changeName` API with flag that mark the room is created before and the same with `changeAvatar`