### PR TITLE
TW-638: fix multiple linebreaks to html

### DIFF
--- a/lib/src/utils/markdown.dart
+++ b/lib/src/utils/markdown.dart
@@ -32,6 +32,17 @@ class LinebreakSyntax extends InlineSyntax {
   }
 }
 
+class MultipleLinebreaksSyntax extends InlineSyntax {
+  MultipleLinebreaksSyntax() : super(r'\n{2,}');
+
+  @override
+  bool onMatch(InlineParser parser, Match match) {
+    parser.addNode(Element.empty('br'));
+    parser.addNode(Element.empty('br'));
+    return true;
+  }
+}
+
 class SpoilerSyntax extends TagSyntax {
   SpoilerSyntax() : super(r'\|\|', requiresDelimiterRun: true);
 
@@ -217,6 +228,7 @@ String markdown(
     ],
     inlineSyntaxes: [
       StrikethroughSyntax(),
+      MultipleLinebreaksSyntax(),
       LinebreakSyntax(),
       SpoilerSyntax(),
       EmoteSyntax(getEmotePacks),
@@ -224,6 +236,7 @@ String markdown(
       MentionSyntax(getMention),
       InlineLatexSyntax(),
     ],
+    inlineOnly : true,
   );
 
   var stripPTags = '<p>'.allMatches(ret).length <= 1;


### PR DESCRIPTION
This replaces successives linebreaks to double br tags

[linagora#638](https://github.com/orgs/linagora/projects/6?pane=issue&itemId=38677570)


https://github.com/linagora/matrix-dart-sdk/assets/48354990/65a72897-3a64-434c-8942-659a700e8236

