### PR TITLE
TW-1735: update isValidMatrixId to fit documentation

### DIFF
--- a/lib/src/utils/matrix_id_string_extension.dart
+++ b/lib/src/utils/matrix_id_string_extension.dart
@@ -42,7 +42,7 @@ extension MatrixIdExtension on String {
     }
     // all other matrix IDs have to have a domain
     final parts = _getParts();
-    // if the localpart starts with an @, localpart must not be empty
+    // if the localpart starts with an @, checks if the user id is valid
     if (substring(0, 1) == '@') {
       return _matchesUserIdRegExp(this);
     }

--- a/lib/src/utils/matrix_id_string_extension.dart
+++ b/lib/src/utils/matrix_id_string_extension.dart
@@ -42,11 +42,22 @@ extension MatrixIdExtension on String {
     }
     // all other matrix IDs have to have a domain
     final parts = _getParts();
+    // if the localpart starts with an @, localpart must not be empty
+    if (substring(0, 1) == '@') {
+      return _matchesUserIdRegExp(this);
+    }
     // the localpart can be an empty string, e.g. for aliases
     if (parts.length != 2 || parts[1].isEmpty) {
       return false;
     }
     return true;
+  }
+
+  bool _matchesUserIdRegExp(String text) {
+    final globalRegExp = RegExp(
+        r'^@([a-z0-9.=_\-\+]+):((?:[a-zA-Z0-9\-]+\.)*[a-zA-Z]{2,}|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|\[(?:[0-9a-fA-F:.]+)\])(?::\d{1,5})?$');
+
+    return globalRegExp.hasMatch(text);
   }
 
   String? get sigil => isValidMatrixId ? substring(0, 1) : null;

--- a/test/matrix_id_string_extension_test.dart
+++ b/test/matrix_id_string_extension_test.dart
@@ -33,7 +33,9 @@ void main() {
       expect('\$testevent'.isValidMatrixId, true);
       expect('test:example.com'.isValidMatrixId, false);
       expect('@testexample.com'.isValidMatrixId, false);
-      expect('@:example.com'.isValidMatrixId, true);
+      expect('@:example.com'.isValidMatrixId, false);
+      expect('@@test:example.com'.isValidMatrixId, false);
+      expect('#:example.com'.isValidMatrixId, true);
       expect('@test:'.isValidMatrixId, false);
       expect(mxId.sigil, '@');
       expect('#test:example.com'.sigil, '#');
@@ -44,6 +46,7 @@ void main() {
       expect(mxId.domain, 'example.com');
       expect(mxId.equals('@Test:example.com'), true);
       expect(mxId.equals('@test:example.org'), false);
+      expect('@user:127.0.0.1:8448'.localpart, 'user');
       expect('@user:domain:8448'.localpart, 'user');
       expect('@user:domain:8448'.domain, 'domain:8448');
     });


### PR DESCRIPTION
If matrix id is a user id, `isValidMatrixId` now checks those conditions:

- the localpart of a user ID is an opaque identifier for that user. 
- it MUST NOT be empty, and MUST contain only the characters a-z, 0-9, ., _, =, -, /, and +
- the hostname can be followed by an optional numeric port specifier. 
- the hostname may be a dotted-quad IPv4 address literal, an IPv6 address literal surrounded with square brackets, or a DNS name.

Source: https://spec.matrix.org/v1.10/appendices/#user-identifiers 