### PR TITLE
Change operator in user from dynamic to object

### DIFF
--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -185,7 +185,7 @@ class User extends Event {
       room.canChangePowerLevel && powerLevel < room.ownPowerLevel;
 
   @override
-  bool operator ==(dynamic other) => (other is User &&
+  bool operator ==(Object other) => (other is User &&
       other.id == id &&
       other.room == room &&
       other.membership == membership);


### PR DESCRIPTION
To be able to mock the User class we need to change the implementation of to use Object instead of dynamic